### PR TITLE
Forklaring av uri-prefix og svelte path

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ You will now deploy a Svelte front end, which has nothing to do with the app you
 
 ### Build and push image to registry
 
- - Navigate to `frontend\svelte.config.js` and update line 16 to a path where you will host the frontend
+ - Navigate to `frontend\svelte.config.js` and update line 16 to a path where you will host the frontend.
+    - This path cannot be the same path as the one you set in `aspnetapp`.
  - Build the frontend image
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,13 +73,14 @@ In Kubernetes, namespaces provide a mechanism for isolating groups of resources 
 ## Task 1
 
 You will now build an image and deploy it to the Azure Container Registry (ACR). 
-All containers must have a unique name within the ACR. 
-During this workshop you should choose a unique prefix so all your images gets a uniqe name, for instance your full name.
+All containers must have a unique name within the ACR.
+
+During this workshop you should choose a unique prefix so all your images gets a uniqe name, for instance your full name. Only use lowercase letters. Use this prefix instead of `<uri-prefix>` in the commands below.
 
 ### Build and push image to registry
  
- - Navigate to `aspnetapp\aspnetapp\Program.cs` and update line 24 with a unique path
- - Build the Dockerfile in `aspnetapp`. Choose a prefix so that all of your images get a unique name and run:
+ - Open `aspnetapp\aspnetapp\Program.cs` and update line 24 with a unique path
+ - Navigate to `aspnetapp` and build the Dockerfile:
 
 ```bash
 az acr build --image <uri-prefix>/aspnet:v1 --registry workshopacrsqr2klsnuxgxa --file Dockerfile .


### PR DESCRIPTION
Små fikser rundt uri-prefix:
- Tydeliggjør at det må være små bokstaver
- Forklar den kun et sted og gjør det tydelig hva den skal brukes til

Spesifiserte også at front end og back end må ha forskjellige paths.